### PR TITLE
Add insync to Cloud Storage list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [Google Drive](https://drive.google.com) - Powerful cloud services by Google.
 - [NextCloud](https://nextcloud.com) - Free, open source cloud storage and collaboration platform.
 - [pCloud](https://www.pcloud.com) - Secure online storage from Switzerland.
+- [insync](https://www.insynchq.com/) - Google Drive and OneDrive file syncing
 
 ## Databases
 


### PR DESCRIPTION
Since there is no official Google Drive client for Linux, InSync is one client that has been filling that space.  